### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Utilities.String.nuspec
+++ b/MakoIoT.Device.Utilities.String.nuspec
@@ -17,7 +17,7 @@
     <description>String extensions for .NET nanoFramework C# projects.</description>
     <tags>nanoFramework C# csharp netmf netnf string</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.16.11" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.17.1" />
       <dependency id="nanoFramework.System.Text" version="1.3.16" />
     </dependencies>
   </metadata>

--- a/src/MakoIoT.Device.Utilities.String/MakoIoT.Device.Utilities.String.nfproj
+++ b/src/MakoIoT.Device.Utilities.String/MakoIoT.Device.Utilities.String.nfproj
@@ -22,8 +22,8 @@
     <Compile Include="Extensions\StringExtension.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.16.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.16.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.17.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.1\lib\mscorlib.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.3.16.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Text.1.3.16\lib\nanoFramework.System.Text.dll</HintPath>

--- a/src/MakoIoT.Device.Utilities.String/packages.config
+++ b/src/MakoIoT.Device.Utilities.String/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.16.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.17.1" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.3.16" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.CoreLibrary from 1.16.11 to 1.17.1</br>
[version update]

### :warning: This is an automated update. :warning:
